### PR TITLE
Track fan's last running speed so it turns on at that speed

### DIFF
--- a/fan-thermostat-device.groovy
+++ b/fan-thermostat-device.groovy
@@ -42,8 +42,12 @@ def parse(command) {
 
     if (attr == "speed") {
         if (value == "off") {
+            state.lastSpeed = device.currentSpeed
             sendEvent(name: "switch", value: "off")
         } else {
+            if (value == "on" && state.lastSpeed) {
+                value = state.lastSpeed
+            }
             sendEvent(name: "switch", value: "on")
         }
     }


### PR DESCRIPTION
This fixes an issue where fan thermostat devices were reporting their speed as "on" for a little while after being turned on.
This happened because the child device didn't know what speed the fan would turn on to until it processed the controlled fan's speed event.  This tracks the last running speed when the fan thermostat device turns off to try to guess what speed the fan will turn on at.