### PR TITLE
Fix driver so that setpoint and mode don't reset to default on reboot

### DIFF
--- a/fan-thermostat-device.groovy
+++ b/fan-thermostat-device.groovy
@@ -18,6 +18,7 @@
 // * Mar 15 2020 - Fix an issue where the device would repor its speed as "on" sometimes
 // * Apr 23 2020 - Add support for the "off" thermostat mode and the
 //                 SwitchLevel capability
+// * Jul 17 2020 - Fix thermostat mode and setpoint reverting to default on hub reboot
 
 metadata {
     definition(
@@ -53,10 +54,10 @@ def updated() {
 
 def initialize() {
     sendEvent(name: "supportedThermostatModes", value: ["off", "cool"])
-    if (currentThermostatMode == null) {
+    if (device.currentThermostatMode == null) {
         setThermostatMode("cool")
     }
-    if (currentThermostatSetpoint == null) {
+    if (device.currentThermostatSetpoint == null) {
         setCoolingSetpoint(78)
     }
 }

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,8 +1,11 @@
 {
   "packageName": "Fan Thermostat",
   "author": "Miles Budnek",
-  "version": "1.1",
+  "version": "1.2",
   "minimumHEVersion": "0.0",
+  "documentationLink": "https://github.com/mbudnek/hubitat-fan-thermostat/blob/master/README.md",
+  "communityLink": "https://community.hubitat.com/t/release-fan-thermostat-with-manual-override/34554",
+  "releaseNotes": "Changelog:\n  * 1.1 - Initial Release\n  * 1.2 - Fix thermostat mode and setpoint reverting to default on hub reboot",
   "dateReleased": "2020-02-17",
   "apps": [
     {


### PR DESCRIPTION
The driver's initialize method was using currentThermostatMode
instead of device.currentThermostatMode to check if an initial
setting already exists.  This caused it to always think the mode
and setpoint were uninitialized and re-initialize them to the
default setting.