### PR TITLE
Fix an issue with manual override not working correctly

### DIFF
--- a/fan-thermostat-device.groovy
+++ b/fan-thermostat-device.groovy
@@ -19,6 +19,7 @@
 // * Apr 23 2020 - Add support for the "off" thermostat mode and the
 //                 SwitchLevel capability
 // * Jul 17 2020 - Fix thermostat mode and setpoint reverting to default on hub reboot
+// * Aug 10 2020 - Fix issue with manual override not working
 
 metadata {
     definition(
@@ -114,11 +115,11 @@ def clearManualOverride() {
 
 def setManualOverride(overrideSeconds=null) {
     if (overrideSeconds == null) {
-        overrideSeconds = settings.defaultManualOverrideTime
+        overrideSeconds = device.currentDefaultManualOverrideTime
     }
     if (overrideSeconds) {
         sendEvent(name: "manualOverride", value: "active")
-        runIn(overrideSeconds, "clearManualOverride")
+        runIn(overrideSeconds.toLong(), "clearManualOverride")
     }
 }
 

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,11 +1,11 @@
 {
   "packageName": "Fan Thermostat",
   "author": "Miles Budnek",
-  "version": "1.2",
+  "version": "1.3",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/hubitat-fan-thermostat/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/release-fan-thermostat-with-manual-override/34554",
-  "releaseNotes": "Changelog:\n  * 1.1 - Initial Release\n  * 1.2 - Fix thermostat mode and setpoint reverting to default on hub reboot",
+  "releaseNotes": "Changelog:\n  * 1.1 - Initial Release\n  * 1.2 - Fix thermostat mode and setpoint reverting to default on hub reboot\n  * 1.3 - Fix issue with manual override",
   "dateReleased": "2020-02-17",
   "apps": [
     {


### PR DESCRIPTION
Fan devices' manual override wasn't getting set automatically and setting it manually resulted in it not automatically clearing after the specified time.

This was due to two bugs:
1. The device was attempting to read the default manual override time from settings instead of its device attribute
2. The manually specified time is passed as a `BigDecimal`, but Hubitat's `runIn` method wants a `Long`

Fixes #7 