### PR TITLE
Fix a couple of issues with controlling switches

### DIFF
--- a/fan-thermostat-child.groovy
+++ b/fan-thermostat-child.groovy
@@ -17,6 +17,7 @@
 // * Mar 01 2020 - Make manualOverride device command paramter optional
 // * Apr 23 2020 - Add support for the "off" thermostat mode and the
 //                 SwitchLevel capability
+// * Aug 17 2020 - Fix broken child device initialization
 
 import groovy.transform.Field
 
@@ -357,7 +358,7 @@ private getFanSpeed() {
 
     def newFanSpeed = childDev.currentSpeed
     if (settings.fanControllers) {
-        fanSpeeds += settings.fanControllers.each { fanController ->
+        settings.fanControllers.each { fanController ->
             if (fanController.currentSpeed != childDev.currentSpeed) {
                 setManualOverride()
                 newFanSpeed = fanController.currentSpeed
@@ -365,7 +366,7 @@ private getFanSpeed() {
         }
     }
     if (settings.switches) {
-        fanSpeeds += settings.switches.collect { sw ->
+        settings.switches.each { sw ->
             if (sw.currentSwitch == "off" && childDev.currentSpeed != "off") {
                 setManualOverride()
                 newFanSpeed = "off"

--- a/fan-thermostat-device.groovy
+++ b/fan-thermostat-device.groovy
@@ -20,6 +20,7 @@
 //                 SwitchLevel capability
 // * Jul 17 2020 - Fix thermostat mode and setpoint reverting to default on hub reboot
 // * Aug 10 2020 - Fix issue with manual override not working
+// * Aug 17 2020 - Fix issue when controlling switches
 
 metadata {
     definition(
@@ -73,7 +74,7 @@ def parse(command) {
             state.lastSpeed = device.currentSpeed
             sendEvent(name: "switch", value: "off")
         } else {
-            if (value == "on" && state.lastSpeed) {
+            if (value == "on" && state.lastSpeed && state.lastSpeed != "off") {
                 value = state.lastSpeed
             }
             sendEvent(name: "switch", value: "on")

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,11 +1,11 @@
 {
   "packageName": "Fan Thermostat",
   "author": "Miles Budnek",
-  "version": "1.3",
+  "version": "1.4",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/hubitat-fan-thermostat/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/release-fan-thermostat-with-manual-override/34554",
-  "releaseNotes": "Changelog:\n  * 1.1 - Initial Release\n  * 1.2 - Fix thermostat mode and setpoint reverting to default on hub reboot\n  * 1.3 - Fix issue with manual override",
+  "releaseNotes": "Changelog:\n  * 1.1 - Initial Release\n  * 1.2 - Fix thermostat mode and setpoint reverting to default on hub reboot\n  * 1.3 - Fix issue with manual override\n  * 1.4 - Fix issues when controlling switches",
   "dateReleased": "2020-02-17",
   "apps": [
     {


### PR DESCRIPTION
This fixes a couple of issues when controlling a switch (not a fan
controller):
1. The `speed` attribute of the thermostat device would never change
   from "off" due to a bug in the driver's `parse` method.
2. The app wouldn't subscribe to any events due to an exception
   that got thrown when initializing it.