### PR TITLE
Check if the fan should run when retrigger time elapses

### DIFF
--- a/fan-thermostat-child.groovy
+++ b/fan-thermostat-child.groovy
@@ -20,6 +20,8 @@
 // * Aug 17 2020 - Fix broken child device initialization
 // * May 17 2021 - Fix errors when using switch with no fan controller
 //                 (i.e. for using with box fan on a switched outlet)
+// * Jun 18 2021 - Retrigger fans immediately when the retrigger time elapses
+//                 rather than waiting for the next sensor event
 
 import groovy.transform.Field
 

--- a/fan-thermostat-child.groovy
+++ b/fan-thermostat-child.groovy
@@ -316,7 +316,14 @@ def motionHandler(evt) {
     controlFans()
 }
 
+def retriggerTimeoutCheck() {
+    controlFans()
+}
+
 def fanSpeedHandler(evt) {
+    if (evt.value == "off") {
+        runIn(settings.retiggerTime, "retriggerTimeoutCheck")
+    }
     def childDev = getThermostatDevice()
     if (evt.value != childDev.currentSpeed) {
         setManualOverride()
@@ -325,6 +332,9 @@ def fanSpeedHandler(evt) {
 }
 
 def switchHandler(evt) {
+    if (evt.value == "off") {
+        runIn(settings.retiggerTime, "retriggerTimeoutCheck")
+    }
     def childDev = getThermostatDevice()
     def childOn = childDev.currentSpeed != "off"
     if (evt.value == "off" && childOn) {

--- a/fan-thermostat-child.groovy
+++ b/fan-thermostat-child.groovy
@@ -324,7 +324,7 @@ def retriggerTimeoutCheck() {
 
 def fanSpeedHandler(evt) {
     if (evt.value == "off") {
-        runIn(settings.retiggerTime, "retriggerTimeoutCheck")
+        runIn(settings.retriggerTime, "retriggerTimeoutCheck")
     }
     def childDev = getThermostatDevice()
     if (evt.value != childDev.currentSpeed) {
@@ -335,7 +335,7 @@ def fanSpeedHandler(evt) {
 
 def switchHandler(evt) {
     if (evt.value == "off") {
-        runIn(settings.retiggerTime, "retriggerTimeoutCheck")
+        runIn(settings.retriggerTime, "retriggerTimeoutCheck")
     }
     def childDev = getThermostatDevice()
     def childOn = childDev.currentSpeed != "off"

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,11 +1,11 @@
 {
   "packageName": "Fan Thermostat",
   "author": "Miles Budnek",
-  "version": "1.5",
+  "version": "1.6",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/hubitat-fan-thermostat/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/release-fan-thermostat-with-manual-override/34554",
-  "releaseNotes": "Changelog:\n  * 1.1 - Initial Release\n  * 1.2 - Fix thermostat mode and setpoint reverting to default on hub reboot\n  * 1.3 - Fix issue with manual override\n  * 1.4 - Fix issues when controlling switches\n  * 1.5 - Fix errors when a child instance uses only switches and no fan controllers",
+  "releaseNotes": "Changelog:\n  * 1.1 - Initial Release\n  * 1.2 - Fix thermostat mode and setpoint reverting to default on hub reboot\n  * 1.3 - Fix issue with manual override\n  * 1.4 - Fix issues when controlling switches\n  * 1.5 - Fix errors when a child instance uses only switches and no fan controllers\n  * 1.6 - Retrigger fans immediately when the retrigger time elapses rather than waiting for the next sensor event",
   "dateReleased": "2020-02-17",
   "apps": [
     {


### PR DESCRIPTION
This change makes fans re-start immediately when the retrigger time
elapses after they stopped before any new events from temperature or
motion sensors are received.  This covers the case where motion stops
for long enough to cause fans to stop, but then becomes active again
before the retrigger time has elapsed.  Previously the fan wouldn't
start again until the next time an event was received, even though
motion was active and the temperature was above the setpoint.  This is
mainly an issue when using virtual sensors to represent various
conditions.