### PR TITLE
Support the ThermostatOperatingState capability

### DIFF
--- a/fan-thermostat-device.groovy
+++ b/fan-thermostat-device.groovy
@@ -21,6 +21,7 @@
 // * Jul 17 2020 - Fix thermostat mode and setpoint reverting to default on hub reboot
 // * Aug 10 2020 - Fix issue with manual override not working
 // * Aug 17 2020 - Fix issue when controlling switches
+// * May 04 2022 - Add support for the ThermostatOperatingState capability
 
 metadata {
     definition(
@@ -37,12 +38,14 @@ metadata {
         capability "ThermostatSetpoint"
         capability "TemperatureMeasurement"
         capability "ThermostatMode"
+        capability "ThermostatOperatingState"
 
         command "setManualOverride", ["number"]
         command "clearManualOverride"
 
         attribute "manualOverride", "enum", ["active", "inactive"]
         attribute "defaultManualOverrideTime", "number"
+        attribute "thermostatOperatingState", "enum", ["cooling", "idle"]
     }
 }
 
@@ -73,11 +76,13 @@ def parse(command) {
         if (value == "off") {
             state.lastSpeed = device.currentSpeed
             sendEvent(name: "switch", value: "off")
+            sendEvent(name: "thermostatOperatingState", value: "idle")
         } else {
             if (value == "on" && state.lastSpeed && state.lastSpeed != "off") {
                 value = state.lastSpeed
             }
             sendEvent(name: "switch", value: "on")
+            sendEvent(name: "thermostatOperatingState", value: "cooling")
         }
     }
     sendEvent(name: attr, value: value)

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,11 +1,11 @@
 {
   "packageName": "Fan Thermostat",
   "author": "Miles Budnek",
-  "version": "1.6",
+  "version": "1.7",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/hubitat-fan-thermostat/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/release-fan-thermostat-with-manual-override/34554",
-  "releaseNotes": "Changelog:\n  * 1.1 - Initial Release\n  * 1.2 - Fix thermostat mode and setpoint reverting to default on hub reboot\n  * 1.3 - Fix issue with manual override\n  * 1.4 - Fix issues when controlling switches\n  * 1.5 - Fix errors when a child instance uses only switches and no fan controllers\n  * 1.6 - Retrigger fans immediately when the retrigger time elapses rather than waiting for the next sensor event",
+  "releaseNotes": "Changelog:\n  * 1.1 - Initial Release\n  * 1.2 - Fix thermostat mode and setpoint reverting to default on hub reboot\n  * 1.3 - Fix issue with manual override\n  * 1.4 - Fix issues when controlling switches\n  * 1.5 - Fix errors when a child instance uses only switches and no fan controllers\n  * 1.6 - Retrigger fans immediately when the retrigger time elapses rather than waiting for the next sensor event\n  * 1.7 - Add the thermostatOperatingState attribute to support the ThermostatOperatingState capability",
   "dateReleased": "2020-02-17",
   "apps": [
     {


### PR DESCRIPTION
This adds the `thermostatOperatingState` attribute to the fan thermostat
device in order to support the ThermostatOperatingState capability.